### PR TITLE
Support for clearing only subset errors

### DIFF
--- a/packages/ember-validations/lib/errors.js
+++ b/packages/ember-validations/lib/errors.js
@@ -4,7 +4,22 @@ Ember.Validations.Errors = Ember.Object.extend({
   },
   clear: function() {
     var keys = Object.keys(this);
+    var only = null;
+    if ( arguments.length > 1 )
+    {
+      only = Array.prototype.slice.apply(arguments);
+    }
+    else if (arguments.length === 1)
+    {
+      if ( arguments[0] instanceof Array )
+        only = arguments[0];
+      else
+        only = [arguments[0]];
+    }
     for(var i = 0; i < keys.length; i++) {
+      if ( only && only.indexOf(keys[i]) < 0 )
+        continue;
+
       this.set(keys[i], undefined);
       delete this[keys[i]];
     }

--- a/packages/ember-validations/tests/errors_test.js
+++ b/packages/ember-validations/tests/errors_test.js
@@ -21,3 +21,13 @@ test('clears existing errors', function() {
   user.errors.clear();
   deepEqual(Object.keys(user.errors), []);
 });
+
+
+test('clear error on some attribute', function() {
+  user.errors.add('firstName', "can't be blank");
+  user.errors.add('lastName', "can't be blank");
+  user.errors.add('email', "can't be blank");
+  deepEqual(Object.keys(user.errors), ['firstName', 'lastName', 'email']);
+  user.errors.clear('firstName', 'email');
+  deepEqual(Object.keys(user.errors), ['lastName']);
+});


### PR DESCRIPTION
Hello,
I made a small patch to allow clear only some errors instead of entire errors hash.
Hoping could be useful.
