### PR TITLE
Add custom validator

### DIFF
--- a/packages/ember-validations/lib/validators.js
+++ b/packages/ember-validations/lib/validators.js
@@ -8,3 +8,5 @@ require('ember-validations/validators/inclusion');
 require('ember-validations/validators/length');
 require('ember-validations/validators/numericality');
 require('ember-validations/validators/presence');
+require('ember-validations/validators/custom');
+

--- a/packages/ember-validations/lib/validators/custom.js
+++ b/packages/ember-validations/lib/validators/custom.js
@@ -1,0 +1,14 @@
+Ember.Validations.validators.local.reopen({
+  custom: function(model, property, validator, deferredObject) {
+    /*jshint expr:true*/
+    var message;
+
+    message = model[validator]();
+
+    if (message) {
+      model.errors.add(property, message);
+    }
+
+    deferredObject && deferredObject.resolve();
+  }
+});

--- a/packages/ember-validations/tests/validators/custom_test.js
+++ b/packages/ember-validations/tests/validators/custom_test.js
@@ -1,0 +1,32 @@
+var model, Model, options;
+
+module('Presence Validator', {
+  setup: function() {
+    Model = Ember.Object.extend(Ember.Validations.Mixin, {
+      validateStartIsBeforeStop: function() {
+        if ( this.get('start') > this.get('stop') ) {
+          return 'Start must be before stop';
+        }
+      }
+    });
+    model = Model.create();
+  }
+});
+
+test('when custom validation function returns a messessage', function() {
+  model.setProperties({
+    start: 2,
+    stop: 1
+  });
+  Ember.Validations.validators.local.custom(model, 'start', 'validateStartIsBeforeStop');
+  equal(model.errors.get('start'), 'Start must be before stop');
+});
+
+test('when custom validation function returns undefined', function() {
+  model.setProperties({
+    start: 1,
+    stop: 2
+  });
+  Ember.Validations.validators.local.presence(model, 'start', 'validateStartIsBeforeStop');
+  deepEqual(model.errors.get('start'), undefined);
+});


### PR DESCRIPTION
Added a local validator `custom`.  It takes only one option, a string naming the function it will run on validation.

``` Javascript

App.Task.reopen({
  validations: {
    start: {
      custom: 'validateStartIsBeforeStop'
    }
  }

  validateStartIsBeforeStop: function() {
    if ( this.get('start') > this.get('stop') ) {
      return 'Start must be before stop';
    }
  }
});
```

I don't know if this is the ideal way to define custom validators but it gets the job done.  I hope this or something like it makes the cut. 
