### PR TITLE
Ported support for validating against a property with the length validator to branch validator-classes

### DIFF
--- a/packages/ember-validations/lib/validators/length.js
+++ b/packages/ember-validations/lib/validators/length.js
@@ -15,7 +15,11 @@ Ember.Validations.validators.local.Length = Ember.Validations.validators.Base.ex
       key = this.messageKeys()[index];
       if (this.options[key] !== undefined && this.options.messages[this.MESSAGES[key]] === undefined) {
         if (Ember.$.inArray(key, this.checkKeys()) !== -1) {
-          this.options.count = this.options[key];
+          if (isNaN(parseFloat(this.options[key])) && this.model.get(this.options[key]) !== undefined) {
+            this.options.count = this.model.get(this.options[key]);
+          } else {
+            this.options.count = this.options[key];
+          }
         }
         this.options.messages[this.MESSAGES[key]] = Ember.Validations.messages.render(this.MESSAGES[key], this.options);
         if (this.options.count !== undefined) {
@@ -59,12 +63,21 @@ Ember.Validations.validators.local.Length = Ember.Validations.validators.Base.ex
       }
     } else {
       for (check in this.CHECKS) {
+        var checkValue;
         operator = this.CHECKS[check];
         if (!this.options[check]) {
           continue;
         }
 
-        fn = new Function('return ' + this.tokenizedLength(this.model.get(this.property)) + ' ' + operator + ' ' + this.options[check]);
+        if (!isNaN(parseFloat(this.options[check])) && isFinite(this.options[check])) {
+          checkValue = this.options[check];
+        } else if (this.model.get(this.options[check]) !== undefined) {
+          checkValue = this.model.get(this.options[check]);
+        } else {
+          return reject();
+        }
+
+        fn = new Function('return ' + this.tokenizedLength(this.model.get(this.property)) + ' ' + operator + ' ' + checkValue);
         if (!fn()) {
           this.model.errors.add(this.property, this.options.messages[this.MESSAGES[check]]);
           return reject();

--- a/packages/ember-validations/tests/validators/length_test.js
+++ b/packages/ember-validations/tests/validators/length_test.js
@@ -144,3 +144,118 @@ test('when allowed length maximum is 3, value length is 4 and no message is set'
   validator.call(fail, pass);
   deepEqual(model.errors.get('attribute'), ['is too long (maximum is 3 characters)']);
 });
+
+
+test('when passed a model property as maximum value, value is 2 and maximum is 4', function() {
+  model.set('attribute', 'ab');
+  model.set('validationProperty', 4);
+  options = { maximum: 'validationProperty' };
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(pass, fail);
+  equal(model.errors.get('attribute'), undefined);
+});
+
+test('when passed a model property as maximum value, value is 2 and maximum is 2', function() {
+  model.set('attribute', 'ab');
+  model.set('validationProperty', 2);
+  options = { maximum: 'validationProperty'};
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(pass, fail);
+  equal(model.errors.get('attribute'), undefined);
+});
+
+test('when passed a model property as maximum value, value is 2 and maximum is 1', function() {
+  model.set('attribute', 'ab');
+  model.set('validationProperty', 1);
+  options = { maximum: 'validationProperty'};
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(fail, pass);
+  deepEqual(model.errors.get('attribute'), ['is too long (maximum is 1 characters)']);
+});
+
+test('when passed a model property as minimum value, value is 1 and minimum is 1', function() {
+  model.set('attribute', 'a');
+  model.set('validationProperty', 1);
+  options = { minimum: 'validationProperty' };
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(pass, fail);
+  equal(model.errors.get('attribute'), undefined);
+});
+
+test('when passed a model attribute as minimum value, value is 1 and minimum is 0', function() {
+  model.set('attribute', 'a');
+  model.set('validationProperty', 0);
+  options = { minimum: 'validationProperty' };
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(pass, fail);
+  equal(model.errors.get('attribute'), undefined);
+});
+
+test('when passed a model attribute as minimum value, value is 1 and minimum is 2', function() {
+  model.set('attribute', 'a');
+  model.set('validationProperty', 2);
+  options = { minimum: 'validationProperty' };
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(fail, pass);
+  deepEqual(model.errors.get('attribute'), ['is too short (minimum is 2 characters)']);
+});
+
+test('when passed a model attribute as a number value, value is 1 and number value is 1', function() {
+  model.set('attribute', 'a');
+  model.set('validationProperty', 1);
+  options = { is: 'validationProperty' };
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(pass, fail);
+  equal(model.errors.get('attribute'), undefined);
+});
+
+test('when passed a model attribute as a number value, value is 1 and number value is 2', function() {
+  model.set('attribute', 'a');
+  model.set('validationProperty', 2);
+  options = { is: 'validationProperty' };
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(fail, pass);
+  deepEqual(model.errors.get('attribute'), ['is the wrong length (should be 2 characters)']);
+});
+
+test('when passed a model attribute as a number value, value is 3 and number value is 2', function() {
+  model.set('attribute', 'abc');
+  model.set('validationProperty', 2);
+  options = { is: 'validationProperty' };
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(fail, pass);
+  deepEqual(model.errors.get('attribute'), ['is the wrong length (should be 2 characters)']);
+});
+
+test('when passed a model attribute as a number value, value is 3 and number value is 2', function() {
+  model.set('attribute', 'abc');
+  model.set('validationProperty', 2);
+  options = { is: 'validationProperty' };
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(fail, pass);
+  deepEqual(model.errors.get('attribute'), ['is the wrong length (should be 2 characters)']);
+});
+
+test('when passed an undefined model attribute as minimum value, value is 1', function() {
+  model.set('attribute', 'a');
+  options = {minimum: 'validationProperty'};
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(fail, pass);
+  deepEqual(model.errors.get('attribute'), undefined);
+});
+
+test('when passed an undefined model attribute as maximum value, value is 1', function() {
+  model.set('attribute', 'a');
+  options = {maximum: 'validationProperty'};
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(fail, pass);
+  deepEqual(model.errors.get('attribute'), undefined);
+});
+
+test('when passed an undefined model attribute as number value, value is 1', function() {
+  model.set('attribute', 'a');
+  options = {is: 'validationProperty'};
+  validator = Ember.Validations.validators.local.Length.create({model: model, property: 'attribute', options: options});
+  validator.call(fail, pass);
+  deepEqual(model.errors.get('attribute'), undefined);
+});


### PR DESCRIPTION
Same as previously, but ported over to the validator-classes branch.

I'm also a little bit uncertain about how the validator should react if the validation value specified is neither a number nor another (defined) property on the model. At the moment I've reused the functionality from the numericality validation – run reject without adding any error messages. 

Should close #29.
