### PR TITLE
Update to latest ember-dev.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gem 'rake-pipeline', :git => 'https://github.com/livingsocial/rake-pipeline.git'
 gem 'ember-dev', :git => 'https://github.com/emberjs/ember-dev.git', :branch => 'master'
 
-gem 'ember-source', '1.0.0'
+gem 'ember-source', '1.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: bc00ea0660b07744067f05d2e12354b183ae4cb1
+  revision: a7821c65c9822a65a224a1897ffa22074e8c8b26
   branch: master
   specs:
     ember-dev (0.1)
@@ -9,6 +9,7 @@ GIT
       execjs
       grit
       kicker
+      puma
       rack
       rake-pipeline (~> 0.8.0)
       rake-pipeline-web-filters (~> 0.7.0)
@@ -16,54 +17,57 @@ GIT
 
 GIT
   remote: https://github.com/livingsocial/rake-pipeline.git
-  revision: 65b1e744defa208e313703d89f3453447cc103b2
+  revision: a75d96fbadcc659a35a0ae59212e0bc60b58cc54
   specs:
     rake-pipeline (0.8.0)
       json
-      rake (~> 10.0.0)
+      rake (~> 10.1.0)
       thor
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.15.0)
+    aws-sdk (1.22.1)
       json (~> 1.4)
-      nokogiri (< 1.6.0)
+      nokogiri (>= 1.4.4, < 1.6.0)
       uuidtools (~> 2.1)
+    celluloid (0.15.2)
+      timers (~> 1.1.0)
     colored (1.2)
     diff-lcs (1.2.4)
-    ember-source (1.0.0)
+    ember-source (1.1.1)
       handlebars-source (= 1.0.12)
-    execjs (2.0.0)
+    execjs (2.0.2)
     ffi (1.9.0)
     grit (2.5.0)
       diff-lcs (~> 1.1)
       mime-types (~> 1.15)
       posix-spawn (~> 0.3.6)
     handlebars-source (1.0.12)
-    json (1.8.0)
+    json (1.8.1)
     kicker (2.6.1)
       listen
-    listen (1.3.0)
+    listen (2.1.1)
+      celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-      rb-kqueue (>= 0.2)
-    mime-types (1.24)
-    multi_json (1.7.9)
+    mime-types (1.25)
+    multi_json (1.8.2)
     nokogiri (1.5.10)
     posix-spawn (0.3.6)
+    puma (2.6.0)
+      rack (>= 1.1, < 2.0)
     rack (1.5.2)
-    rake (10.0.4)
+    rake (10.1.0)
     rake-pipeline-web-filters (0.7.0)
       rack
       rake-pipeline (~> 0.6)
     rb-fsevent (0.9.3)
-    rb-inotify (0.9.1)
-      ffi (>= 0.5.0)
-    rb-kqueue (0.2.0)
+    rb-inotify (0.9.2)
       ffi (>= 0.5.0)
     thor (0.18.1)
-    uglifier (2.2.0)
+    timers (1.1.0)
+    uglifier (2.2.1)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
     uuidtools (2.1.4)
@@ -73,5 +77,5 @@ PLATFORMS
 
 DEPENDENCIES
   ember-dev!
-  ember-source (= 1.0.0)
+  ember-source (= 1.1.1)
   rake-pipeline!

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -29,7 +29,7 @@
   }
 
   EmberDev.distros = {
-    spade:   'ember-spade.js',
+    spade:   'ember-validations-spade.js',
     build:   'ember-validations.js'
   };
 })();


### PR DESCRIPTION
`ember-dev` has been updated to only include `bundler/gem_tasks` when actually
releasing a gem.

`ember-dev` now uses the dasherized project name (from `ember-dev.yml`) for
the generated spade file. This allows us to test multiple projects at once
without having a naming collision on `ember-spade.js`.

I also updated `ember-source` to 1.1.1 (latest stable).
