### PR TITLE
Fix license file.

### DIFF
--- a/generators/license.js
+++ b/generators/license.js
@@ -1,5 +1,5 @@
 // ==========================================================================
 // Project:   Ember Validations
-// Copyright: © 2013 DockYar, LLC. and contributors.
+// Copyright: Copyright 2013 DockYard, LLC. and contributors.
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================


### PR DESCRIPTION
The current file uses © (correct UTF copyright symbol), but when generated into the build artifacts (as ASCII text) it looks garbled (`// Copyright: Â©2013`).

References: 
- http://www.copyright.gov/circs/circ01.pdf
- http://stackoverflow.com/questions/221376/putting-copyright-symbol-into-a-python-file#221380
