### PR TITLE
Include license info in all builds.

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -17,6 +17,7 @@ distros.each do |name, modules|
 
     match "#{name}.js" do
       filter VersionInfo
+      filter EmberLicenseFilter
     end
 
     # Strip dev code


### PR DESCRIPTION
Prior to this PR only the minified output would include the license.
