### PR TITLE
Fix errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,20 +271,20 @@ After mixing in `Ember.Validations.Mixin` into your object it will now have a
 for the corresponding property. Errors messages will always be an array.
 
 ```javascript
-App.User = Ember.Object.extend(Ember.Validations.Mixin,
-  validations:
+App.User = Ember.Object.extend(Ember.Validations.Mixin, {
+  validations: {
     firstName: { presence: true }
   }
 });
 
 user = App.User.create();
-user.validate().then(null, function(errors) {
+user.validate().then(null, function() {
   user.get('isValid'); // false
-  errors.get('firstName'); // ["can't be blank"]
+  user.get('errors.firstName'); // ["can't be blank"]
   user.set('firstName', 'Brian');
-  user.validate().then(function(errors) {
+  user.validate().then(function() {
     user.get('isValid'); // true
-    errors.get('firstName'); // []
+    user.get('errors.firstName'); // []
   })
 })
 


### PR DESCRIPTION
Hi!

I tried the example in README.md but the version throws an error when being pasted into the console. Tried with Version 1.0.0.beta1.

Extending the user class with the validation mixin misses some curly brackets and the .then part of the validation example is not up to date with at least beta version of 1.0.0.

The promise does not resolve with an error object and thus can't be inspected. The error object is present on the user instance though as stated in the README.

Best regards,
Mike
