### PR TITLE
Inactive validators should be considered valid

### DIFF
--- a/packages/ember-validations/lib/validators/base.js
+++ b/packages/ember-validations/lib/validators/base.js
@@ -31,24 +31,24 @@ Ember.Validations.validators.Base = Ember.Object.extend({
     }
   },
   validate: function() {
+    this.errors.clear();
     if (this.canValidate()) {
-      this.errors.clear();
       this.call();
-      if (this.errors.length > 0) {
-        if (this.get('isValid') === false) {
-          this.notifyPropertyChange('isValid');
-        } else {
-          this.set('isValid', false);
-        }
-        return Ember.RSVP.reject(this.get('model.errors'));
+    }
+    if (this.errors.length > 0) {
+      if (this.get('isValid') === false) {
+        this.notifyPropertyChange('isValid');
       } else {
-        if (this.get('isValid') === true) {
-          this.notifyPropertyChange('isValid');
-        } else {
-          this.set('isValid', true);
-        }
-        return Ember.RSVP.resolve(this.get('model.errors'));
+        this.set('isValid', false);
       }
+      return Ember.RSVP.reject(this.get('model.errors'));
+    } else {
+      if (this.get('isValid') === true) {
+        this.notifyPropertyChange('isValid');
+      } else {
+        this.set('isValid', true);
+      }
+      return Ember.RSVP.resolve(this.get('model.errors'));
     }
   }.on('init'),
   canValidate: function() {

--- a/packages/ember-validations/tests/validators/base_test.js
+++ b/packages/ember-validations/tests/validators/base_test.js
@@ -29,3 +29,25 @@ test('generates _dependentValidationKeys on the model', function() {
   });
   deepEqual(model.get('_dependentValidationKeys'), {attribute: ['otherAttribute']});
 });
+
+test('inactive validators should be considered valid', function() {
+  var canValidate = true;
+  Ember.run(function() {
+    validator = CustomValidator.createWithMixins({
+      model: model,
+      property: 'attribute',
+      canValidate: function() {
+        return canValidate;
+      },
+      call: function() {
+        this.errors.pushObject("nope");
+      }
+    });
+  });
+  equal(validator.get('isValid'), false);
+  canValidate = false;
+  Ember.run(validator, 'validate');
+  equal(validator.get('isValid'), true);
+});
+
+


### PR DESCRIPTION
/cc @rwjblue

If a validator is "inactive" due to its provided `if` conditional evaling to
false, it should be considered valid rather than preserving its list of
errors.
