### PR TITLE
Revalidates arrays when they are replaced.

### DIFF
--- a/packages/ember-validations/lib/mixin.js
+++ b/packages/ember-validations/lib/mixin.js
@@ -21,7 +21,7 @@ var pushValidatableObject = function(model, property) {
 
   model.removeObserver(property, pushValidatableObject);
   if (Ember.isArray(content)) {
-    model.validators.pushObject(ArrayValidatorProxy.create({model: model, property: property, content: content}));
+    model.validators.pushObject(ArrayValidatorProxy.create({model: model, property: property, contentBinding: 'model.' + property}));
   } else {
     model.validators.pushObject(content);
   }

--- a/packages/ember-validations/tests/validate_test.js
+++ b/packages/ember-validations/tests/validate_test.js
@@ -244,3 +244,66 @@ test('validates array of validable objects', function() {
 
   equal(user.get('isValid'), true);
 });
+
+
+test('revalidates arrays when they are replaced', function() {
+  var friend1, friend2;
+
+  Ember.run(function() {
+    user = User.create({
+      validations: {
+        friends: true
+      }
+    });
+  });
+
+  equal(user.get('isValid'), true);
+
+  Ember.run(function() {
+    user.set('friends', Ember.makeArray());
+  });
+
+  equal(user.get('isValid'), true);
+
+  Ember.run(function() {
+    friend1 = User.create({
+      validations: {
+        name: {
+          presence: true
+        }
+      }
+    });
+  });
+
+  Ember.run(function() {
+    user.set('friends', [friend1]);
+  });
+
+  equal(user.get('isValid'), false);
+
+  Ember.run(function() {
+    friend1.set('name', 'Stephanie');
+  });
+
+  equal(user.get('isValid'), true);
+
+  Ember.run(function() {
+    friend2 = User.create({
+      validations: {
+        name: {
+          presence: true
+        }
+      }
+    });
+
+    user.set('friends', [friend1, friend2]);
+  });
+
+  equal(user.get('isValid'), false);
+
+  Ember.run(function() {
+    user.friends.removeObject(friend2);
+  });
+
+  equal(user.get('isValid'), true);
+});


### PR DESCRIPTION
When an array was replaced the validator was not being updated, it was just validating the original array.

This problem occurred especially in computed properties that depend on arrays.

``` javascript
model = Ember.Object.extend({
   items: [],
   visibleItems: function() {
     // a new array will be created every time this computed property is updated,
     // but just the original array was being validated.
     return this.get('myArray').filterBy('isDeleted', false);
  }.property('items.@each.isDeleted')
});

model.reopen({
  validations: {
    visibleItems: true
  }
});
```
