### PR TITLE
Set default numericality message when messages is defined, but messages.numericality is not.

### DIFF
--- a/packages/ember-validations/lib/validators/numericality.js
+++ b/packages/ember-validations/lib/validators/numericality.js
@@ -16,6 +16,10 @@ Ember.Validations.validators.local.Numericality = Ember.Validations.validators.B
       this.options.messages = { numericality: Ember.Validations.messages.render('notANumber', this.options) };
     }
 
+    if (this.options.messages.numericality === undefined) {
+      this.options.messages.numericality = Ember.Validations.messages.render('notANumber', this.options);
+    }
+
     if (this.options.onlyInteger !== undefined && this.options.messages.onlyInteger === undefined) {
       this.options.messages.onlyInteger = Ember.Validations.messages.render('notAnInteger', this.options);
     }


### PR DESCRIPTION
There seems to be some confusion about how the default numericality message is defined after a messages object is defined without a numericality message and I believe this change makes it more intuitive while not breaking backward compatibility.

https://github.com/dockyard/ember-validations/issues/95#issuecomment-35816835
