### PR TITLE
Possible correction sans hack.

### DIFF
--- a/packages/ember-validations/lib/ext/controllerMixin.js
+++ b/packages/ember-validations/lib/ext/controllerMixin.js
@@ -1,14 +1,14 @@
-Ember.ControllerMixin.reopen({
-  childControllers: Ember.A(),
-  setupAsChildController: function() {
-    if (this.parentController) {
-      this.parentController.childControllers.pushObject(this);
-      this.reopen({
-        willDestroy: function() {
-          this._super();
-          this.parentController.childControllers.removeObject(this);
-        }
-      });
-    }
-  }.on('init')
-});
+// Ember.ControllerMixin.reopen({
+//   childControllers: Ember.A(),
+//   setupAsChildController: function() {
+//     if (this.parentController) {
+//       this.parentController.childControllers.pushObject(this);
+//       this.reopen({
+//         willDestroy: function() {
+//           this._super();
+//           this.parentController.childControllers.removeObject(this);
+//         }
+//       });
+//     }
+//   }.on('init')
+// });

--- a/packages/ember-validations/tests/validate_test.js
+++ b/packages/ember-validations/tests/validate_test.js
@@ -103,7 +103,7 @@ test('can be mixed into an array controller', function() {
     itemController: 'User',
     container: container,
     validations: {
-      childControllers: true
+      '[]': true
     }
   });
 


### PR DESCRIPTION
I believe the intent of the validation in the test is to say "this array
controller is valid when all its children are valid".  I believe this change
achieves those semantics, although please keep in mind that I have not studied
the implementation of ember-validations so this approach should only be taken if
it makes sense to someone who understands the internals of ember-validations.
