### PR TITLE
Fix for ember-data isValid conflict which can make .rollback() impossible.

### DIFF
--- a/packages/ember-validations/lib/mixin.js
+++ b/packages/ember-validations/lib/mixin.js
@@ -1,7 +1,8 @@
 var setValidityMixin = Ember.Mixin.create({
-  isValid: function() {
-    return this.get('isClientValid') && (!this.get('currentState') || this.get('currentState.isValid'));
-  }.property('isClientValid', 'currentState.isValid'),
+  isValid: Ember.computed.and('isClientValid', 'isServerValid'),
+  isServerValid: Ember.computed.or('isNotUsingEmberData', 'isEmberDataValid'),
+  isNotUsingEmberData: Ember.computed.not('currentState'),
+  isEmberDataValid: Ember.computed.alias('currentState.isValid'),
   isClientValid: function() {
     return this.get('validators').compact().filterBy('isValid', false).get('length') === 0;
   }.property('validators.@each.isValid'),


### PR DESCRIPTION
For those using ember-validations AND ember-data, ember-validations overriding `isValid` completely makes it impossible to rollback a model after a save that fails due to server validation errors.

Scenario:
- Try to save a model which ends up in a server validation error (but is valid according to ember-validations).
  - Ember-data sets `currentState.isValid` to `false`.  Ember-data's implementation of `isValid` is basically just an alias for `currentState.isValid` ([ember-data source](https://github.com/emberjs/data/blob/20adb1d5b0db0058b9fda35265c9916f2fe7c964/packages/ember-data/lib/system/model/model.js#L194)).
  - The `isValid` property on the model ends up remaining `true` in this scenario because ember-validations has completely overridden ember-data's implementation of `isValid`.
- Then call `.rollback()` on your model which is in a valid state according to ember-validations, but not according to ember-data.
  - The rollback fails because ember-data will only clear the `_inFlightAttributes` if `!model.isValid` or `model.isError` ([ember-data source](https://github.com/emberjs/data/blob/20adb1d5b0db0058b9fda35265c9916f2fe7c964/packages/ember-data/lib/system/model/model.js#L831-L838)), neither of which are true in this scenario because ember-validations is completely overriding ember-data's implementation of `isValid`.

The Fix:
- `isValid` should check if the client is valid (ember-validations) AND if there are any server validation errors (if ember-data is being used).

Note: I linked the currently most recent commit in the above links in case the line numbers end up changing.
