### PR TITLE
Add LocalValidator and RemoteValidator base classes and Uniqueness validator

### DIFF
--- a/packages/ember-validations/lib/defaultMessages.js
+++ b/packages/ember-validations/lib/defaultMessages.js
@@ -33,6 +33,8 @@ Ember.Validations.messages = {
     otherThan: "must be other than {{count}}",
     odd: "must be odd",
     even: "must be even",
+    defaultRemoteValidation: "failed remote validation",
+    uniqueness: "has already been taken",
     url: "is not a valid URL"
   }
 };

--- a/packages/ember-validations/lib/validators.js
+++ b/packages/ember-validations/lib/validators.js
@@ -1,5 +1,7 @@
 require('ember-validations/validatorNamespaces');
 require('ember-validations/validators/base');
+require('ember-validations/validators/local-validator');
+require('ember-validations/validators/remote-validator');
 require('ember-validations/validators/absence');
 require('ember-validations/validators/acceptance');
 require('ember-validations/validators/confirmation');
@@ -10,3 +12,4 @@ require('ember-validations/validators/length');
 require('ember-validations/validators/numericality');
 require('ember-validations/validators/presence');
 require('ember-validations/validators/url');
+require('ember-validations/validators/uniqueness');

--- a/packages/ember-validations/lib/validators/absence.js
+++ b/packages/ember-validations/lib/validators/absence.js
@@ -1,4 +1,4 @@
-Ember.Validations.validators.local.Absence = Ember.Validations.validators.Base.extend({
+Ember.Validations.validators.local.Absence = Ember.Validations.validators.LocalValidator.extend({
   init: function() {
     this._super();
     /*jshint expr:true*/

--- a/packages/ember-validations/lib/validators/acceptance.js
+++ b/packages/ember-validations/lib/validators/acceptance.js
@@ -1,4 +1,4 @@
-Ember.Validations.validators.local.Acceptance = Ember.Validations.validators.Base.extend({
+Ember.Validations.validators.local.Acceptance = Ember.Validations.validators.LocalValidator.extend({
   init: function() {
     this._super();
     /*jshint expr:true*/

--- a/packages/ember-validations/lib/validators/base.js
+++ b/packages/ember-validations/lib/validators/base.js
@@ -43,15 +43,11 @@ Ember.Validations.validators.Base = Ember.Object.extend({
     });
   },
   _validate: function() {
-    this.errors.clear();
-    if (this.canValidate()) {
-      this.call();
-    }
-    if (this.get('isValid')) {
-      return Ember.RSVP.resolve(true);
-    } else {
-      return Ember.RSVP.resolve(false);
-    }
+   try {
+     throw '_validate function not implemented';
+   } catch(error) {
+     Ember.Logger.error(error);
+   }
   }.on('init'),
   canValidate: function() {
     if (typeof(this.conditionals) === 'object') {

--- a/packages/ember-validations/lib/validators/confirmation.js
+++ b/packages/ember-validations/lib/validators/confirmation.js
@@ -1,4 +1,4 @@
-Ember.Validations.validators.local.Confirmation = Ember.Validations.validators.Base.extend({
+Ember.Validations.validators.local.Confirmation = Ember.Validations.validators.LocalValidator.extend({
   init: function() {
     this.originalProperty = this.property;
     this.property = this.property + 'Confirmation';

--- a/packages/ember-validations/lib/validators/exclusion.js
+++ b/packages/ember-validations/lib/validators/exclusion.js
@@ -1,4 +1,4 @@
-Ember.Validations.validators.local.Exclusion = Ember.Validations.validators.Base.extend({
+Ember.Validations.validators.local.Exclusion = Ember.Validations.validators.LocalValidator.extend({
   init: function() {
     this._super();
     if (this.options.constructor === Array) {

--- a/packages/ember-validations/lib/validators/format.js
+++ b/packages/ember-validations/lib/validators/format.js
@@ -1,4 +1,4 @@
-Ember.Validations.validators.local.Format = Ember.Validations.validators.Base.extend({
+Ember.Validations.validators.local.Format = Ember.Validations.validators.LocalValidator.extend({
   init: function() {
     this._super();
     if (this.options.constructor === RegExp) {

--- a/packages/ember-validations/lib/validators/inclusion.js
+++ b/packages/ember-validations/lib/validators/inclusion.js
@@ -1,4 +1,4 @@
-Ember.Validations.validators.local.Inclusion = Ember.Validations.validators.Base.extend({
+Ember.Validations.validators.local.Inclusion = Ember.Validations.validators.LocalValidator.extend({
   init: function() {
     this._super();
     if (this.options.constructor === Array) {

--- a/packages/ember-validations/lib/validators/length.js
+++ b/packages/ember-validations/lib/validators/length.js
@@ -1,4 +1,4 @@
-Ember.Validations.validators.local.Length = Ember.Validations.validators.Base.extend({
+Ember.Validations.validators.local.Length = Ember.Validations.validators.LocalValidator.extend({
   init: function() {
     var index, key;
     this._super();

--- a/packages/ember-validations/lib/validators/local-validator.js
+++ b/packages/ember-validations/lib/validators/local-validator.js
@@ -1,0 +1,13 @@
+Ember.Validations.validators.LocalValidator = Ember.Validations.validators.Base.extend({
+  _validate: function() {
+    this.errors.clear();
+    if (this.canValidate()) {
+      this.call();
+    }
+    if (this.get('isValid')) {
+      return Ember.RSVP.resolve(true);
+    } else {
+      return Ember.RSVP.resolve(false);
+    }
+  }.on('init')
+});

--- a/packages/ember-validations/lib/validators/numericality.js
+++ b/packages/ember-validations/lib/validators/numericality.js
@@ -1,4 +1,4 @@
-Ember.Validations.validators.local.Numericality = Ember.Validations.validators.Base.extend({
+Ember.Validations.validators.local.Numericality = Ember.Validations.validators.LocalValidator.extend({
   init: function() {
     /*jshint expr:true*/
     var index, keys, key;

--- a/packages/ember-validations/lib/validators/presence.js
+++ b/packages/ember-validations/lib/validators/presence.js
@@ -1,4 +1,4 @@
-Ember.Validations.validators.local.Presence = Ember.Validations.validators.Base.extend({
+Ember.Validations.validators.local.Presence = Ember.Validations.validators.LocalValidator.extend({
   init: function() {
     this._super();
     /*jshint expr:true*/

--- a/packages/ember-validations/lib/validators/remote-validator.js
+++ b/packages/ember-validations/lib/validators/remote-validator.js
@@ -1,0 +1,132 @@
+Ember.Validations.validators.RemoteValidator = Ember.Validations.validators.Base.extend({
+  init: function() {
+    /*jshint expr:true*/
+    this._super();
+
+    if (typeof(this.options) === 'function') {
+      this.set('optionsCallBack', this.options);
+    } else if (this.options === true) {
+      // Do nothing
+    } else {
+      try {
+        throw 'remote validations must be declared as a function';
+      }
+      catch(error) {
+        Ember.Logger.error(error);
+      }
+    }
+
+    this.set('options', {});
+    this.setOptions();
+
+    // Make model invalid by default
+    // Not the best - should have a default error message that is added to the
+    // errors hash before server validations have run. Eg: 'has not been validated'
+    this.errors.pushObject(this.options.message);
+  },
+
+  _validate: function() {
+    if (this.canValidate()) {
+      this.validateRemotely();
+    }
+    if (this.get('isValid')) {
+      return Ember.RSVP.resolve(true);
+    } else {
+      return Ember.RSVP.resolve(false);
+    }
+  }.on('init'),
+
+  // Sets the options to send with the ajax request and wraps the call() funciton in a debounce
+  validateRemotely: function() {
+    this.setOptions();
+
+    if (this.options.url !== undefined) {
+      Ember.run.debounce(this, this.call, this.options.debounce);
+    }
+  },
+
+  setOptions: function() {
+    this.setDefaultOptions();
+
+    // Run the optionsCallBack and merge it with the options hash if the validation was
+    // declared as a function.
+    if (this.get('optionsCallBack')) {
+      // Maybe add a guard in here to check that the value returned by the optionsCallBack is a hash before trying to merge it.
+      var updatedOptions = Ember.$.extend({}, this.get('options'), this.optionsCallBack());
+      this.set('options', updatedOptions);
+    }
+
+    this.verifyRequiredOptions();
+  },
+
+  setDefaultOptions: function() {
+    // This function can be overwritten to set default options for the ajax request.
+    // Eg:
+    //
+    // this.set('options', {
+      // url: '/api/v1/remote_validation',
+      // debounce: 700,
+      // errorOnStauts: [200, 500],
+      // message: 'that email has been blacklisted....',
+      // data: {
+        // email: this.get('model.email')
+      // }
+    // });
+
+    if (this.options.data === undefined) {
+      this.set('options.data', {});
+    }
+
+    if (this.options.message === undefined) {
+      this.set('options.message', Ember.Validations.messages.render('defaultRemoteValidation', this.options));
+    }
+
+    if (this.options.debounce === undefined) {
+      this.set('options.debounce', 300);
+    }
+
+    if (this.options.errorOnStatus === undefined) {
+      this.set('options.errorOnStatus', Ember.makeArray([404, 422, 500]));
+    }
+  },
+
+  verifyRequiredOptions: function() {
+    var self = this,
+    requiredOptions = Ember.makeArray(['url', 'message', 'debounce', 'errorOnStatus']);
+
+    requiredOptions.forEach(function(option) {
+      // Throw error if option in requiredOptions array is undefined.
+      if (self.get('options.' + option) === undefined) {
+        try {
+          throw 'must specify ' + option  + ' option for remote validation';
+        }
+        catch(error) {
+          Ember.Logger.error(error);
+        }
+      }
+    });
+  },
+
+  call: function() {
+    this._super();
+
+    // This function should be overwritten when creating a new Validator and inheriting from RemoteValidator.
+    // It should initiate an asyc request to the back end, passing in self.get('options'). Errors should be cleared
+    // out and added depending on the response from the server. Eg:
+    //
+    // var self = this,
+    //     errorOnStatus = Ember.makeArray(this.get('options.errorOnStatus'));
+
+    // function resolveServerResponse(data, textStatus, xhr) {
+      // self.errors.clear();
+
+      // // Add errors if server responds with http status code contained within the errorOnStatus array.
+      // if (errorOnStatus.contains(data.status) || errorOnStatus.contains(xhr.status)) {
+        // self.errors.pushObject(self.options.message);
+      // }
+    // }
+
+    // // Use resolveServerResponse function for both resolve and reject states
+    // Ember.$.ajax(self.get('options')).then(resolveServerResponse, resolveServerResponse);
+  }
+});

--- a/packages/ember-validations/lib/validators/uniqueness.js
+++ b/packages/ember-validations/lib/validators/uniqueness.js
@@ -1,0 +1,42 @@
+Ember.Validations.validators.remote.Uniqueness = Ember.Validations.validators.RemoteValidator.extend({
+  setDefaultOptions: function() {
+    var self         = this,
+        propertyData = {};
+
+    propertyData[this.property] = this.model.get(this.property);
+
+    function options() {
+      return {
+        // Would like some feedback on a good default url endpoint for validation.
+        // Was originally thinking something Ember.Router.namespace + this.property + '/uniqueness'
+        // url: '/api/v1/' + this.property + '/uniqueness',
+        message: Ember.Validations.messages.defaults.uniqueness,
+        debounce: 300,
+        errorOnStatus: [404, 422, 500],
+        data: {
+          object: self.get('model.model._attributes'),
+          property: propertyData
+        }
+      };
+    }
+
+    this.set('options', options());
+  },
+
+  call: function() {
+    var self = this,
+        errorOnStatus = Ember.makeArray(this.get('options.errorOnStatus'));
+
+    function resolveServerResponse(data, textStatus, xhr) {
+      self.errors.clear();
+
+      // Add errors if server responds with http status code contained within the errorOnStatus array.
+      if (errorOnStatus.contains(data.status) || errorOnStatus.contains(xhr.status)) {
+        self.errors.pushObject(self.options.message);
+      }
+    }
+
+    // Use resolveServerResponse function for both resolve and reject states
+    Ember.$.ajax(self.get('options')).then(resolveServerResponse, resolveServerResponse);
+  }
+});

--- a/packages/ember-validations/lib/validators/url.js
+++ b/packages/ember-validations/lib/validators/url.js
@@ -1,4 +1,4 @@
-Ember.Validations.validators.local.Url = Ember.Validations.validators.Base.extend({
+Ember.Validations.validators.local.Url = Ember.Validations.validators.LocalValidator.extend({
   regexp: null,
   regexp_ip: null,
 

--- a/packages/ember-validations/tests/validators/base_test.js
+++ b/packages/ember-validations/tests/validators/base_test.js
@@ -3,7 +3,7 @@ var model, Model, options, CustomValidator, validator;
 module('Base Validator', {
   setup: function() {
     Model = Ember.Object.extend(Ember.Validations.Mixin);
-    CustomValidator = Ember.Validations.validators.Base.extend({
+    CustomValidator = Ember.Validations.validators.LocalValidator.extend({
       init: function() {
         this._super();
         this._dependentValidationKeys.pushObject('otherAttribute');


### PR DESCRIPTION
The RemoteValidator class requires validators that inherit from it to overwrite the default `call` function. The `call` function should implement an ajax call and pass in `this.options` as it's arguments. The `call` function should also handle clearing and adding errors based on the response from the server. See example: https://github.com/dockyard/ember-validations/pull/117/files#diff-c9875bc6e129a611ffcdf206f262d01dR25 

Validators that inherit from RemoteValidator can optionally override the `setDefaultOptions` function to set default options parameters (Eg: set the default error message, set a default api endpoint where the validation will take place).

Remote validations can be declared by passing in `true` (if all required options have been set in the `setDefaultOptions` function) or as a function that returns a hash of options. Eg:

``` javascript
  email: {
    uniqueness: true // This currently doesn't work - there isn't a default url for uniqueness validation yet
  }
```

or

``` javascript
  email: {
    uniqueness: function() {
      return {
        url: '/api/v1/uniqueness',
        debounce: 500,
        message: "you've been blacklisted...",
        errorOnStatus: [404, 422, 500],    // Defaults to [404, 422, 500]. Can override with array or integer
        data: {
          email: this.get('email'),
          name: this.get('name')
        }
      }
    }
  }
```

The reason for declaring the validation as a function rather than a hash is so we can pass in something like `this.get('email')` and have the value be evaluated dynamically.
