### PR TITLE
Fixed issue where addObserver was getting called w undef prop

### DIFF
--- a/packages/ember-validations/lib/validators/numericality.js
+++ b/packages/ember-validations/lib/validators/numericality.js
@@ -25,13 +25,14 @@ Ember.Validations.validators.local.Numericality = Ember.Validations.validators.B
     for(index = 0; index < keys.length; index++) {
       key = keys[index];
 
-      if (isNaN(this.options[key])) {
-        this.model.addObserver(this.options[key], this, this._validate);
+      var prop = this.options[key];
+      if (key in this.options && isNaN(prop)) {
+        this.model.addObserver(prop, this, this._validate);
       }
 
-      if (this.options[key] !== undefined && this.options.messages[key] === undefined) {
+      if (prop !== undefined && this.options.messages[key] === undefined) {
         if (Ember.$.inArray(key, Ember.keys(this.CHECKS)) !== -1) {
-          this.options.count = this.options[key];
+          this.options.count = prop;
         }
         this.options.messages[key] = Ember.Validations.messages.render(key, this.options);
         if (this.options.count !== undefined) {

--- a/packages/ember-validations/tests/validators/numericality_test.js
+++ b/packages/ember-validations/tests/validators/numericality_test.js
@@ -335,3 +335,28 @@ test('when other messages are passed but not a numericality message', function()
   });
   deepEqual(validator.errors, ['is not a number']);
 });
+
+test("numericality validators don't call addObserver on null props", function() {
+  expect(1);
+
+  var stubbedObserverCalled = false;
+
+  var realAddObserver = Ember.addObserver;
+  Ember.addObserver = function(_, path) {
+    stubbedObserverCalled = true;
+    if (!path) {
+      ok(false, "shouldn't call addObserver with falsy path");
+    }
+    return realAddObserver.apply(this, arguments);
+  };
+
+  options = { lessThanOrEqualTo: 10 };
+  Ember.run(function() {
+    validator = Ember.Validations.validators.local.Numericality.create({model: model, property: 'attribute', options: options});
+    model.set('attribute', 11);
+  });
+  Ember.addObserver = realAddObserver;
+
+  ok(stubbedObserverCalled, "stubbed addObserver was called");
+});
+


### PR DESCRIPTION
Newer Ember versions seem to be bitten by this.
