### PR TITLE
Make validator observer run after validator call

### DIFF
--- a/packages/ember-validations/lib/mixin.js
+++ b/packages/ember-validations/lib/mixin.js
@@ -43,7 +43,7 @@ Ember.Validations.Mixin = Ember.Mixin.create(setValidityMixin, {
     }
     this.buildValidators();
     this.validators.forEach(function(validator) {
-      validator.addObserver('errors.[]', this, function(sender, key, value, context, rev) {
+      validator.addObserver('errors.@each', this, function(sender, key, value, context, rev) {
         var errors = Ember.makeArray();
         this.validators.forEach(function(validator) {
           if (validator.property === sender.property) {


### PR DESCRIPTION
Hey,

I'm not sure what in current Canary  (1.6.0.xxxxx ) causes the observed validator's errors get invoked before the validator set its errors when observing errors.[], but changing to errors.@each make it run properly.
