### PR TITLE
Fixed condition in confirmation validator for not string values

### DIFF
--- a/packages/ember-validations/lib/validators/confirmation.js
+++ b/packages/ember-validations/lib/validators/confirmation.js
@@ -11,8 +11,13 @@ Ember.Validations.validators.local.Confirmation = Ember.Validations.validators.B
     }
   },
   call: function() {
-    if (this.model.get(this.originalProperty) !== this.model.get(this.property)) {
-      this.errors.pushObject(this.options.message);
+    var original = this.model.get(this.originalProperty);
+    var confirmation = this.model.get(this.property);
+
+    if(!Ember.isEmpty(original) || !Ember.isEmpty(confirmation)) {
+      if (original !== confirmation) {
+        this.errors.pushObject(this.options.message);
+      }
     }
   }
 });

--- a/packages/ember-validations/tests/validators/confirmation_test.js
+++ b/packages/ember-validations/tests/validators/confirmation_test.js
@@ -42,6 +42,22 @@ test('when values do not match', function() {
   deepEqual(validator.errors, ['failed validation']);
 });
 
+test('when original is null', function() {
+  Ember.run(function() {
+    validator = Ember.Validations.validators.local.Confirmation.create({model: model, property: 'attribute'});
+    model.set('attribute', null);
+  });
+  deepEqual(validator.errors, []);
+});
+
+test('when confirmation is null', function() {
+  Ember.run(function() {
+    validator = Ember.Validations.validators.local.Confirmation.create({model: model, property: 'attribute'});
+    model.set('attributeConfirmation', null);
+  });
+  deepEqual(validator.errors, []);
+});
+
 test('when options is true', function() {
   options = true;
   Ember.run(function() {


### PR DESCRIPTION
This PR fixes the `!==` comparator issue if one value is `null` and the other one is `undefined` for example.
It seems to be the same issue here : https://github.com/dockyard/ember-validations/issues/127

Keep up the good work :)
