### PR TITLE
Mention the convenience property `isInvalid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ firstName: {
 
 Validations will automatically run when the object is created and when
 each property changes. `isValid` states bubble up and help define the
-direct parent's validation state.
+direct parent's validation state. `inInvalid` is also available for convenience.
 
 If you want to force all validations to run simply call `.validate()` on the object. `isValid` will be set to `true`
 or `false`. All validations are run as deferred objects, so the validations will
@@ -279,8 +279,8 @@ completed.
 
 ```javascript
 user.validate().then(function() {
-  user.get('isValid');
-  // true
+  user.get('isValid'); // true
+  user.get('inInvalid'); // false
 })
 ```
 


### PR DESCRIPTION
[packages/ember-validations/lib/mixin.js#L5](https://github.com/dockyard/ember-validations/blob/2bd028670a72c962fb7ababd9ddd0125dba4df38/packages/ember-validations/lib/mixin.js#L5) has made available a `isInvalid` which is the opposite of `isValid` (duh).

It's worth mentioning in the `README.md` that it exists and can be used.
