### PR TITLE
Fix typo for isInvalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ firstName: {
 
 Validations will automatically run when the object is created and when
 each property changes. `isValid` states bubble up and help define the
-direct parent's validation state. `inInvalid` is also available for convenience.
+direct parent's validation state. `isInvalid` is also available for convenience.
 
 If you want to force all validations to run simply call `.validate()` on the object. `isValid` will be set to `true`
 or `false`. All validations are run as deferred objects, so the validations will
@@ -280,7 +280,7 @@ completed.
 ```javascript
 user.validate().then(function() {
   user.get('isValid'); // true
-  user.get('inInvalid'); // false
+  user.get('isInvalid'); // false
 })
 ```
 


### PR DESCRIPTION
Sadly I managed to typo `isInvalid` from #139.

[My emperor I have failed you](https://www.youtube.com/watch?v=Wz0d2acCBG8).
