### PR TITLE
Fix numericality message

### DIFF
--- a/packages/ember-validations/lib/validators/numericality.js
+++ b/packages/ember-validations/lib/validators/numericality.js
@@ -14,7 +14,7 @@ Ember.Validations.validators.local.Numericality = Ember.Validations.validators.B
 
     if (this.options.messages === undefined || this.options.messages.numericality === undefined) {
       this.options.messages = this.options.messages || {};
-      this.options.messages = { numericality: Ember.Validations.messages.render('notANumber', this.options) };
+      this.options.messages.numericality = Ember.Validations.messages.render('notANumber', this.options);
     }
 
     if (this.options.onlyInteger !== undefined && this.options.messages.onlyInteger === undefined) {

--- a/packages/ember-validations/tests/validators/numericality_test.js
+++ b/packages/ember-validations/tests/validators/numericality_test.js
@@ -336,6 +336,15 @@ test('when other messages are passed but not a numericality message', function()
   deepEqual(validator.errors, ['is not a number']);
 });
 
+test('when greaterThan fails and a greaterThan message is passed but not a numericality message', function() {
+  options = { greaterThan: 11, messages: { greaterThan: 'custom message' } };
+  Ember.run(function() {
+    validator = Ember.Validations.validators.local.Numericality.create({model: model, property: 'attribute', options: options});
+    model.set('attribute', 10);
+  });
+  deepEqual(validator.errors, ['custom message']);
+});
+
 test("numericality validators don't call addObserver on null props", function() {
   expect(1);
 


### PR DESCRIPTION
When a custom message is set for numericality checks but there's no custom
numericality message, custom messages are overwritten.
