### PR TITLE
Allow properties with more than two levels

### DIFF
--- a/packages/ember-validations/lib/mixin.js
+++ b/packages/ember-validations/lib/mixin.js
@@ -32,6 +32,13 @@ var ArrayValidatorProxy = Ember.ArrayProxy.extend(setValidityMixin, {
   validators: Ember.computed.alias('content')
 });
 
+function setRecursively(self, property, errors) {
+  var properties = property.split('.');
+  for (var i = 1; i <= properties.length; i++) {
+    self.set('errors.' + properties.slice(0, i).join('.'), errors);
+  }
+}
+
 Ember.Validations.Mixin = Ember.Mixin.create(setValidityMixin, {
   init: function() {
     this._super();
@@ -50,7 +57,7 @@ Ember.Validations.Mixin = Ember.Mixin.create(setValidityMixin, {
             errors = errors.concat(validator.errors);
           }
         }, this);
-        this.set('errors.' + sender.property, errors);
+        setRecursively(this, sender.property, errors);
       });
     }, this);
   },


### PR DESCRIPTION
Without this fix, I was unable to validate properties more than two levels away, e.g. `attributeA.attributeB.attributeC`.
