### PR TITLE
Support dynamic/per-model validators by allowing a function that returns...

### DIFF
--- a/packages/ember-validations/lib/mixin.js
+++ b/packages/ember-validations/lib/mixin.js
@@ -58,7 +58,7 @@ Ember.Validations.Mixin = Ember.Mixin.create(setValidityMixin, {
     var property, validator;
 
     for (property in this.validations) {
-      if (this.validations[property].constructor === Object) {
+      if (this.validations[property].constructor === Function || this.validations[property].constructor === Object) {
         this.buildRuleValidator(property);
       } else {
         this.buildObjectValidator(property);
@@ -67,11 +67,12 @@ Ember.Validations.Mixin = Ember.Mixin.create(setValidityMixin, {
   },
   buildRuleValidator: function(property) {
     var validator;
-    for (validator in this.validations[property]) {
-      if (this.validations[property].hasOwnProperty(validator)) {
-        this.validators.pushObject(findValidator(validator).create({model: this, property: property, options: this.validations[property][validator]}));
+      var validations = this.validations[property].constructor === Function ? this.validations[property].apply(this) : this.validations[property];
+      for (validator in validations) {
+        if (validations.hasOwnProperty(validator)) {
+          this.validators.pushObject(findValidator(validator).create({model: this, property: property, options: validations[validator]}));
+        }
       }
-    }
   },
   buildObjectValidator: function(property) {
     if (Ember.isNone(this.get(property))) {


### PR DESCRIPTION
... a validator object.

This solves a problem I had, where I wanted each model to have a different validation object. 
In the controller, the validation object looks like this:
validations: {
        value: function() {
            return this.get("validator");
        }
    }

And the models look like this:
{.... validator: {presence: true}}
{.... validator: {numericality: {onlyInteger:true, greaterThan: 0}}}

Not sure if there is already another way to solve this with ember-validations. This is my first Ember project and I'm just getting started with it. But just in case this happens to be useful I thought I'd share.
