### PR TITLE
Fix typo in README.md (Withoug)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ in `local/` or `remote/` has a higher lookup presedence over those in
 The "native" validators that come with `ember-validations` have the
 lowest lookup priority.
 
-### Withoug Ember-CLI ###
+### Without Ember-CLI ###
 
 You can add your validators to the global object:
 


### PR DESCRIPTION
Fix a typo in the README.md (Withoug -> Without)
