### PR TITLE
Removes Ember 1.X from the testing matrix, leaving only LTS, beta and canary

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import Errors from 'ember-validations/errors';
 import Base from 'ember-validations/validators/base';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   A: emberArray,
@@ -11,6 +10,7 @@ const {
   computed,
   computed: { alias, not },
   get,
+  getOwner,
   isArray,
   isNone,
   isPresent,

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,53 +2,6 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
-    },
-    {
-      name: 'ember-1.11',
-      bower: {
-        dependencies: {
-          'ember': '~1.11.0'
-        },
-        resolutions: {
-          'ember': '~1.11.0'
-        }
-      }
-    },
-    {
-      name: 'ember-1.12',
-      bower: {
-        dependencies: {
-          'ember': '~1.12.0'
-        },
-        resolutions: {
-          'ember': '~1.12.0'
-        }
-      }
-    },
-    {
-      name: 'ember-1.13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2',
-      bower: {
-        dependencies: {
-          "ember": "~2.0.0"
-        }
-      }
-    },
-    {
       name: 'ember-lts',
       bower: {
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "^1.0.0"
+    "ember-cli-babel": "^5.1.7"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Unless someone has a good reason and motivation to keep supporting Ember 1.X, I'd suggest making the addon 2.X only.